### PR TITLE
Fixed OnUpdate to work with current patchlevel of Classic (1.31.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ a guild mate asked me if there is a stopwatch addon in vanilla, because this cou
 ![B45Msfy.png](https://bitbucket.org/repo/EdrbMj/images/317516246-B45Msfy.png)  
 
 **Commands:**  
-/sw show  
-/sw hide  
-/sw scale (Number)  
+/stw show
+/stw hide
+/stw scale (Number)
 
 
 cheers,  

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ a guild mate asked me if there is a stopwatch addon in vanilla, because this cou
 ![B45Msfy.png](https://bitbucket.org/repo/EdrbMj/images/317516246-B45Msfy.png)  
 
 **Commands:**  
-/stw show
-/stw hide
-/stw scale (Number)
+/stw show  
+/stw hide  
+/stw scale (Number)  
 
 
 cheers,  

--- a/StopWatch.lua
+++ b/StopWatch.lua
@@ -43,7 +43,7 @@ function StopWatch:Reset()
 	StopWatchFrame_Time:SetText(StopWatch:TimeFormat(Time))
 end
 
-function StopWatch:OnUpdate(self, elapsed)
+function StopWatch_OnUpdate(self, elapsed)
 	if Timer then
 		Time = Time + elapsed
 		StopWatchFrame_Time:SetText(StopWatch:TimeFormat(Time))

--- a/StopWatch.lua
+++ b/StopWatch.lua
@@ -17,7 +17,7 @@ function StopWatch:Initialize()
 			local scale = string.sub(msg, 7)
 			StopWatchFrame:SetScale(tonumber(scale))
 		else
-			StopWatch:SendMessage("Those commands are available:")
+			StopWatch:SendMessage("These commands are available:")
 			StopWatch:SendMessage("- show (BSP: /stw show)")
 			StopWatch:SendMessage("- hide (BSP: /stw hide)")
 			StopWatch:SendMessage("- scale (BSP: /stw scale 1.5)")

--- a/StopWatch.xml
+++ b/StopWatch.xml
@@ -30,17 +30,15 @@
 		</Layers>
 		<Scripts>
 			<OnLoad>
-				getglobal(this:GetName().."_Time"):SetText("00:00:00:00")
+				_G[self:GetName().."_Time"]:SetText("00:00:00:00")
 				StopWatch:Initialize()
 			</OnLoad>
-			<OnUpdate>
-				StopWatch:OnUpdate(this, arg1)
-			</OnUpdate>
+			<OnUpdate function="StopWatch_OnUpdate" />
 			<OnMouseUp>
-				this:StopMovingOrSizing()
+				self:StopMovingOrSizing()
 			</OnMouseUp>
 			<OnMouseDown>
-				this:StartMoving()
+				self:StartMoving()
 			</OnMouseDown>
 		</Scripts>
 		<Frames>


### PR DESCRIPTION
Hello,

I am using Tukui which does not allow for the ingame stopwatch. I found you addon and after mingling a bit to get elapsed variable to work, i now have made it work on the current release of Vanilla (Wow Classic).

If you like the changes, i want to contribute back.

Also, thank you for making it initially!

Best regards
Casper